### PR TITLE
Add “Script” as a key replacement option

### DIFF
--- a/PowerKey/PKAppDelegate.h
+++ b/PowerKey/PKAppDelegate.h
@@ -11,6 +11,7 @@
 
 NSString *const kPowerKeyReplacementKeycodeKey;
 NSString *const kPowerKeyShouldShowPreferencesWindowWhenLaunchedKey;
+NSString *const kPowerKeyScriptPathKey;
 
 @interface PKAppDelegate : NSObject <NSApplicationDelegate>
 

--- a/PowerKey/PKAppDelegate.m
+++ b/PowerKey/PKAppDelegate.m
@@ -13,13 +13,15 @@
 
 NSString *const kPowerKeyReplacementKeycodeKey = @"kPowerKeyReplacementKeycodeKey";
 NSString *const kPowerKeyShouldShowPreferencesWindowWhenLaunchedKey = @"kPowerKeyShouldShowPreferencesWindowWhenLaunchedKey";
+NSString *const kPowerKeyScriptPathKey = @"kPowerKeyScriptPathKey";
 
 @implementation PKAppDelegate
 
 - (void)applicationDidFinishLaunching:(NSNotification *)aNotification
 {
     NSDictionary *defaultPrefs = @{kPowerKeyReplacementKeycodeKey : [NSNumber numberWithInteger:kVK_ForwardDelete],
-                                   kPowerKeyShouldShowPreferencesWindowWhenLaunchedKey : @YES};
+                                   kPowerKeyShouldShowPreferencesWindowWhenLaunchedKey : @YES,
+                                   kPowerKeyScriptPathKey: @""};
     [[NSUserDefaults standardUserDefaults] registerDefaults:defaultPrefs];
     
     [[PKPowerKeyEventListener sharedEventListener] monitorPowerKey];

--- a/PowerKey/PKPowerKeyEventListener.h
+++ b/PowerKey/PKPowerKeyEventListener.h
@@ -11,6 +11,7 @@
 @interface PKPowerKeyEventListener : NSObject
 
 @property (assign) CGKeyCode powerKeyReplacementKeyCode;
+@property (copy) NSString *scriptPath;
 
 + (PKPowerKeyEventListener *)sharedEventListener;
 - (void)monitorPowerKey;

--- a/PowerKey/PKPreferencesController.h
+++ b/PowerKey/PKPreferencesController.h
@@ -8,7 +8,10 @@
 
 #import <Cocoa/Cocoa.h>
 
-@interface PKPreferencesController : NSWindowController
+const NSInteger kPowerKeyDeadKeyTag;
+const NSInteger kPowerKeyScriptTag;
+
+@interface PKPreferencesController : NSWindowController<NSOpenSavePanelDelegate>
 
 @property (nonatomic, retain) IBOutlet NSPopUpButton *powerKeySelector;
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Choose from one of the following Power key replacements.
  - Escape
  - Tab
  - F13
+ - Script
 
 ## Additional steps for OS X 10.9 Mavericks
 


### PR DESCRIPTION
This branch adds `Script` as a key replacement option.

I was having an issue with a service I wrote and globally bound to the `F13` key (System Preferences → Keyboard → Shortcuts). `F13` would launch the service, but *only after* I clicked the app menu (which holds the `Services` sub-menu)—it seems others have had [the same issue](http://superuser.com/a/553134). Thus, PowerKey would not consistently work on my headless media-server.

Note: I did not update the `etc/screenshots/remappingOptions_small.png` screenshot.