### PR TITLE
Added support for touchid single/triple clicks

### DIFF
--- a/PowerKey/PKPowerKeyEventListener.m
+++ b/PowerKey/PKPowerKeyEventListener.m
@@ -190,7 +190,7 @@ CGEventRef copyEventTapCallBack(CGEventTapProxy proxy, CGEventType type, CGEvent
             CFRelease(inputEvent);
         }
         
-    } else if ((powerKeyEvent2 || powerKeyEvent3 || ejectKeyEvent2 || ejectKeyEvent3 || touchidKeyEvent2 || touchidKeyEvent3) && keyCode != NX_KEYTYPE_SOUND_UP) {
+    } else if (powerKeyEvent2 || powerKeyEvent3 || ejectKeyEvent2 || ejectKeyEvent3) {
         
         // Block the second and third events. (JDL: Unless the key is SOUND_UP)
         replacementEvent = nullEvent;

--- a/PowerKey/PKPowerKeyEventListener.m
+++ b/PowerKey/PKPowerKeyEventListener.m
@@ -190,9 +190,9 @@ CGEventRef copyEventTapCallBack(CGEventTapProxy proxy, CGEventType type, CGEvent
             CFRelease(inputEvent);
         }
         
-    } else if (powerKeyEvent2 || powerKeyEvent3 || ejectKeyEvent2 || ejectKeyEvent3 || touchidKeyEvent2 || touchidKeyEvent3) {
+    } else if ((powerKeyEvent2 || powerKeyEvent3 || ejectKeyEvent2 || ejectKeyEvent3 || touchidKeyEvent2 || touchidKeyEvent3) && keyCode != NX_KEYTYPE_SOUND_UP) {
         
-        // Block the second and third events.
+        // Block the second and third events. (JDL: Unless the key is SOUND_UP)
         replacementEvent = nullEvent;
         
     } else {

--- a/PowerKey/PKPowerKeyEventListener.m
+++ b/PowerKey/PKPowerKeyEventListener.m
@@ -121,6 +121,12 @@ CGEventRef copyEventTapCallBack(CGEventTapProxy proxy, CGEventType type, CGEvent
             eventSubtypeString = @"NX_SUBTYPE_EJECT_KEY";
         } else if (event.subtype == NX_SUBTYPE_AUX_CONTROL_BUTTONS) {
             eventSubtypeString = @"NX_SUBTYPE_AUX_CONTROL_BUTTONS";
+        } else if (event.subtype == NX_SUBTYPE_MENU) {
+            // JDL: Single click on TouchID button
+            eventSubtypeString = @"NX_SUBTYPE_MENU";
+        } else if (event.subtype == NX_SUBTYPE_ACCESSIBILITY) {
+            // JDL: Triple click on TouchID button
+            eventSubtypeString = @"NX_SUBTYPE_ACCESSIBILITY";
         } else {
             eventSubtypeString = [NSString stringWithFormat:@"%@", @(event.subtype)];
         }
@@ -148,10 +154,16 @@ CGEventRef copyEventTapCallBack(CGEventTapProxy proxy, CGEventType type, CGEvent
     BOOL ejectKeyEvent1 = (event.subtype == NX_SUBTYPE_EJECT_KEY);
     BOOL ejectKeyEvent2 = (keyCode == NX_KEYTYPE_EJECT && event.subtype == NX_SUBTYPE_AUX_CONTROL_BUTTONS && keyState == 1);
     BOOL ejectKeyEvent3 = (keyCode == NX_KEYTYPE_EJECT && event.subtype == NX_SUBTYPE_AUX_CONTROL_BUTTONS && keyState == 0);
+
+    // JDL: This handles a single or triple press on the TouchID button
+    BOOL touchidKeyEvent1 = (event.subtype == NX_SUBTYPE_MENU || event.subtype == NX_SUBTYPE_ACCESSIBILITY);
+    // JDL: NX_KEYTYPE_SOUND_UP seems to match keyCode 0
+    BOOL touchidKeyEvent2 = (keyCode == NX_KEYTYPE_SOUND_UP && event.subtype == NX_SUBTYPE_AUX_CONTROL_BUTTONS && keyState == 1);
+    BOOL touchidKeyEvent3 = (keyCode == NX_KEYTYPE_SOUND_UP && event.subtype == NX_SUBTYPE_AUX_CONTROL_BUTTONS && keyState == 0);
     
     CGEventRef replacementEvent = systemEvent;
     
-    if (powerKeyEvent1 || ejectKeyEvent1) {
+    if (powerKeyEvent1 || ejectKeyEvent1 || touchidKeyEvent1) {
         
         // Block first Power or Eject key event
         replacementEvent = nullEvent;
@@ -178,7 +190,7 @@ CGEventRef copyEventTapCallBack(CGEventTapProxy proxy, CGEventType type, CGEvent
             CFRelease(inputEvent);
         }
         
-    } else if (powerKeyEvent2 || powerKeyEvent3 || ejectKeyEvent2 || ejectKeyEvent3) {
+    } else if (powerKeyEvent2 || powerKeyEvent3 || ejectKeyEvent2 || ejectKeyEvent3 || touchidKeyEvent2 || touchidKeyEvent3) {
         
         // Block the second and third events.
         replacementEvent = nullEvent;


### PR DESCRIPTION
On the MacBook Pros with Touchbar, touchID has subtype 16 for single clicks (NX_SUBTYPE_MENU) or 17 for triple clicks (NX_SUBTYPE_ACCESSIBILITY).

I have added support for those, however double clicks do nothing and there is a significant delay between keypresses on the TouchID button.