### PR TITLE
Add "Target Display Mode" as an option

### DIFF
--- a/PowerKey/PKPowerKeyEventListener.m
+++ b/PowerKey/PKPowerKeyEventListener.m
@@ -118,6 +118,7 @@ CGEventRef copyEventTapCallBack(CGEventTapProxy proxy, CGEventType type, CGEvent
     BOOL touchIDKeyEventTripleTap = ((short)event.subtype == NX_SUBTYPE_ACCESSIBILITY);
     
     CGEventRef replacementEvent = systemEvent;
+    uint64_t maskEvent = 0;
     
     if (powerKeyEvent1 || ejectKeyEvent1 || touchIDKeyEventSingleTap || touchIDKeyEventTripleTap) {
         
@@ -135,9 +136,18 @@ CGEventRef copyEventTapCallBack(CGEventTapProxy proxy, CGEventType type, CGEvent
             [PKScriptController runScript];
             
         } else {
+            
+            // Modify event if entering Target Display Mode
+            if(replacementKeyCode == kPowerKeyTargetDisplayMode) {
+                
+                replacementKeyCode = kVK_F2;
+                maskEvent = kCGEventFlagMaskCommand;
+                
+            }
+                
             CGEventSourceRef eventSource = CGEventSourceCreate(kCGEventSourceStateHIDSystemState);
             CGEventRef inputEvent = CGEventCreateKeyboardEvent(eventSource, replacementKeyCode, true);
-            CGEventSetFlags(inputEvent, CGEventGetFlags(systemEvent));
+            CGEventSetFlags(inputEvent, CGEventGetFlags(systemEvent) ^ maskEvent);
             CFRelease(eventSource);
             
             // Better performance by posting the newly created event as a new keyboard event,

--- a/PowerKey/PKPreferencesWindowController.h
+++ b/PowerKey/PKPreferencesWindowController.h
@@ -10,6 +10,7 @@
 
 const NSInteger kPowerKeyDeadKeyTag;
 const NSInteger kPowerKeyScriptTag;
+const NSInteger kPowerKeyTargetDisplayMode;
 
 @interface PKPreferencesWindowController : NSWindowController<NSOpenSavePanelDelegate>
 

--- a/PowerKey/PKPreferencesWindowController.m
+++ b/PowerKey/PKPreferencesWindowController.m
@@ -14,6 +14,8 @@
 
 const NSInteger kPowerKeyDeadKeyTag = 0xDEAD;
 const NSInteger kPowerKeyScriptTag = 0xC0DE;
+const NSInteger kPowerKeyTargetDisplayMode = 0xB000;
+
 
 @interface PKPreferencesWindowController ()
 
@@ -67,6 +69,7 @@ const NSInteger kPowerKeyScriptTag = 0xC0DE;
                                @[@"Enter", @(kVK_ANSI_KeypadEnter)],
                                @[@"F13", @(kVK_F13)],
                                @[@"Script", @(kPowerKeyScriptTag)],
+                               @[@"Target Display Mode", @(kPowerKeyTargetDisplayMode)],
                                ];
     
     return replacements;


### PR DESCRIPTION
Some iMac's offer [Target Display Mode](https://support.apple.com/en-us/HT204592) that allow them to be used as monitors. The shortcut to enter this is ⌘ + F2 which requires you to plug a keyboard in just to turn the computer into a monitor.