### PR TITLE
Display alert directing user to needed macOS security permissions

### DIFF
--- a/PowerKey/PKPowerKeyEventListener.m
+++ b/PowerKey/PKPowerKeyEventListener.m
@@ -62,16 +62,16 @@ CFMachPortRef eventTap;
     
     eventTap = CGEventTapCreate(kCGSessionEventTap, kCGHeadInsertEventTap, kCGEventTapOptionDefault, eventTypeMask, copyEventTapCallBack, NULL);
     
-    if (!eventTap) {
+    if (eventTap) {
+        CFRunLoopSourceRef runLoopSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, eventTap, 0);
+        CFRunLoopAddSource(CFRunLoopGetCurrent(), runLoopSource, kCFRunLoopCommonModes);
+        
+        CGEventTapEnable(eventTap, true);
+        
+        CFRelease(runLoopSource);
+    } else {
         exit(YES);
     }
-    
-    CFRunLoopSourceRef runLoopSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, eventTap, 0);
-    CFRunLoopAddSource(CFRunLoopGetCurrent(), runLoopSource, kCFRunLoopCommonModes);
-    
-    CGEventTapEnable(eventTap, true);
-    
-    CFRelease(runLoopSource);
 }
 
 CGEventRef copyEventTapCallBack(CGEventTapProxy proxy, CGEventType type, CGEventRef event, void *refcon) {

--- a/PowerKey/PKPowerKeyEventListener.m
+++ b/PowerKey/PKPowerKeyEventListener.m
@@ -70,6 +70,12 @@ CFMachPortRef eventTap;
         
         CFRelease(runLoopSource);
     } else {
+        NSAlert *alert = [[NSAlert alloc] init];
+        [alert setMessageText:@"Unable to monitor the power key"];
+        [alert setInformativeText:@"This is likely due to a permissions issue. Please grant access for PowerKey:\n\nSystem Preferences > Security & Privacy > Privacy\n\nAdd permission for 'Accessibility' and 'Input Monitoring'."];
+        [alert addButtonWithTitle:@"Quit"];
+        [alert runModal];
+        
         exit(YES);
     }
 }


### PR DESCRIPTION
PowerKey needs the following permissions to function.

 > System Preferences > Security & Privacy > Privacy

Add PowerKey to the security groups for `Accessibility` and `Input Monitoring` (10.15+)

This PR adds an alert directing the user to add those permissions, rather than just quitting:

---

 > ### Unable to monitor the power key
 > This is likely due to a permissions issue. Please grant access for PowerKey:
 > System Preferences > Security & Privacy > Privacy
 > Add permission for 'Accessibility' and 'Input Monitoring'.